### PR TITLE
Fix Domain Lookup Validation

### DIFF
--- a/opensrs/backwardcompatibility/dataconversion/domains/lookup/LookupDomain.php
+++ b/opensrs/backwardcompatibility/dataconversion/domains/lookup/LookupDomain.php
@@ -25,7 +25,7 @@ class LookupDomain extends DataConversion
     //  to ->attributes->domain in the new format
     protected $newStructure = array(
         'attributes' => array(
-            'domain' => 'data->searchstring',
+            'domain' => 'data->domain',
             ),
         );
 


### PR DESCRIPTION
OpenSRS API docs state you need to input a domain but the validation throws an error saying domain not provided. This is because the validation is looking for searchstring.